### PR TITLE
final cut pro版本10.4问题修复

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,8 @@ $ ./srt2fcpxml -srt /tmp/test.srt
 ```
 
 在 srt 文件的目录中会自动生成以srt文件名命名的`fcpxml`文件。
+
+版本注意
+
+如果final cut pro 版本为10.4，将生成的fcpxml文件使用编辑软件(如sublime)打开后，将 ```<fcpxml version="1.8">``` 修改成 ```<fcpxml version="1.7">```
+


### PR DESCRIPTION
当final cut pro 版本为10.4时，导入时提示:“无法识别 DTD 版本。”
将 ```<fcpxml version="1.8">``` 修改成 ```<fcpxml version="1.7">```